### PR TITLE
Returns the longest matching path for more accuracy

### DIFF
--- a/lib/related-view.coffee
+++ b/lib/related-view.coffee
@@ -1,4 +1,5 @@
 {SelectListView} = require('atom-space-pen-views')
+path = require('path')
 
 _existsTemplate = (item) ->
   """
@@ -49,10 +50,13 @@ class RelatedViewSelect extends SelectListView
         @show() if shouldShow
       )
 
-  getRoot: (filename, paths) ->
-    for pathName in paths
-      if filename.indexOf(pathName) >= 0
-        return pathName
+  getRoot: (filePath, rootPaths) ->
+    rootPaths = ("#{rootPath}/" for rootPath in rootPaths)
+
+    until rootPaths.indexOf("#{filePath}/") >= 0
+      filePath = path.dirname(filePath)
+
+    return filePath
 
   populate: ->
     currentPath = atom.workspace.getActiveTextEditor().getPath()


### PR DESCRIPTION
Problem: If you have open projects with similar names, say '/my/project_abc' and '/my/project_a', and you look for a related file on '/my/project_abc', the plugin will actually look under '/my/project_a', because that matches the indexOf condition.

This fixes that issue by returning the longest matching path instead.
