### PR TITLE
Allow activating related file in separate pane

### DIFF
--- a/lib/related-view.coffee
+++ b/lib/related-view.coffee
@@ -27,7 +27,7 @@ class RelatedViewSelect extends SelectListView
   confirmed: (item) ->
     @cancel()
 
-    atom.workspace.open(item.fsPath)
+    atom.workspace.open(item.fsPath, { searchAllPanes: true })
 
   getFilterKey: ->
     'displayPath'


### PR DESCRIPTION
`related` activates the related file if it has already been opened *in the same pane* (rather than opening another buffer onto the file).

This PR ensures that this behavior also applies when the file has been opened in a different pane: rather than re-opening the file in the current pane, it will activate the existing copy of the file.